### PR TITLE
Fixed the CI to work for Ubuntu vanilla compilation.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,4 +30,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ubuntu
-          path: target/release/*
+          path: .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,6 @@ jobs:
         features:
           - ""
           - "cuda"
-          - "vulkan"
-          - "metal"
         include:
           - os: ubuntu-latest
             features: "cuda"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,5 +62,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.os }}-${{ matrix.features }}
-          path: |
-        target/release/ltengine*
+          path: target/release/ltengine*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,16 +6,7 @@ on:
 jobs:
   build:
     name: Build and Test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        features:
-          - ""
-          - "cuda"
-        include:
-          - os: ubuntu-latest
-            features: "cuda"
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -29,24 +20,14 @@ jobs:
           override: true
 
       - name: Build
-        run: |
-          if [ "${{ matrix.features }}" != "" ]; then
-            cargo build --release --features ${{ matrix.features }}
-          else
-            cargo build --release
-          fi
+        run: cargo build --release
 
       - name: Run Tests
-        run: |
-          if [ "${{ matrix.features }}" != "" ]; then
-            cargo test --features ${{ matrix.features }}
-          else
-            cargo test
-          fi
+        run: cargo test
 
       - name: Upload Artifact
         if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.os }}-${{ matrix.features }}
+          name: ubuntu
           path: target/release/ltengine*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,6 @@ jobs:
         include:
           - os: ubuntu-latest
             features: "cuda"
-          - os: ubuntu-latest
-            features: "vulkan"
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,7 @@ jobs:
         run: cargo test
 
       - name: Upload Artifact
-        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v4
         with:
           name: ubuntu
-          path: .
+          path: target/release/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,12 +16,6 @@ jobs:
           - "vulkan"
           - "metal"
         include:
-          - os: macos-latest
-            features: "metal"
-          - os: windows-latest
-            features: "cuda"
-          - os: windows-latest
-            features: "vulkan"
           - os: ubuntu-latest
             features: "cuda"
           - os: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest]
         features:
           - ""
           - "cuda"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
             features: "vulkan"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload Artifact
         if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}-${{ matrix.features }}
           path: target/release/ltengine*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          submodules: 'recursive'
 
       - name: Set up Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,6 @@ name: Build and Test
 
 on:
   push:
-    tags:
-      - 'v*'
   pull_request:
     branches:
       - main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,4 +30,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ubuntu
-          path: target/release/ltengine*
+          path: target/release/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,6 @@ name: Build and Test
 
 on:
   push:
-  pull_request:
-    branches:
-      - main
 
 jobs:
   build:


### PR DESCRIPTION
The CI now build on push (no tag required); only for Ubuntu vanilla.

Good indicator of the codebase health and useful to provide binaries for release