### PR TITLE
Return HTTP 503 after 120s lock wait instead of blocking indefinitely

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1382,9 +1382,11 @@ dependencies = [
  "hf-hub",
  "llama-cpp-2",
  "once_cell",
+ "parking_lot",
  "serde",
  "serde_json",
  "static-files",
+ "thiserror",
  "whatlang",
 ]
 

--- a/ltengine/Cargo.toml
+++ b/ltengine/Cargo.toml
@@ -13,6 +13,8 @@ actix-web-static-files = "4.0"
 static-files = "0.2.1"
 hf-hub = { version = "0.3.2" }
 anyhow = "1.0.97"
+thiserror = { workspace = true }
+parking_lot = "0.12.5"
 llama-cpp-2 = { path = "../llama-cpp-rs/llama-cpp-2", version = "0.1.109" }
 encoding_rs = "0.8.35"
 actix-multipart = "0.7.2"

--- a/ltengine/src/llm.rs
+++ b/ltengine/src/llm.rs
@@ -10,8 +10,15 @@ use llama_cpp_2::sampling::LlamaSampler;
 use llama_cpp_2::{send_logs_to_tracing, LogOptions};
 use std::num::NonZeroU32;
 use std::path::PathBuf;
-use std::sync::Mutex;
+use parking_lot::Mutex;
+use std::time::Duration;
 use anyhow::{Result, Context};
+
+#[derive(Debug, thiserror::Error)]
+pub enum LLMError {
+    #[error("Server busy, please try again later")]
+    Busy,
+}
 
 /// Query total VRAM (MiB) on device 0 using llama.cpp's backend API.
 /// Works for both CUDA and Vulkan builds; returns None for CPU builds.
@@ -65,7 +72,7 @@ fn pick_n_ubatch(use_gpu: bool) -> u32 {
 pub struct LLM {
     backend: LlamaBackend,
     model: LlamaModel,
-    prompt_lock: Mutex<bool>,
+    prompt_lock: Mutex<()>,
     n_ubatch: u32,
 }
 
@@ -97,7 +104,7 @@ impl LLM {
         let use_gpu = !cpu && cfg!(any(feature = "cuda", feature = "vulkan"));
         let n_ubatch = pick_n_ubatch(use_gpu);
 
-        Ok(LLM { backend, model, prompt_lock: Mutex::new(true), n_ubatch })
+        Ok(LLM { backend, model, prompt_lock: Mutex::new(()), n_ubatch })
     }
 
     pub fn create_context(&self, ctx_size: i32) -> Result<LLMContext>{
@@ -133,12 +140,12 @@ impl LLM {
         let ctx_size: i32 = tokens_list.len() as i32 * 3;
         // Lock before create_context: context allocation uses GPU resources and
         // two concurrent allocations corrupt each other even before inference starts.
-        let _lock = self.prompt_lock.lock();
         // TODO: The llama bindings (or llama itself?) do not appear to be totally thread-safe
         // as garbage starts to come out when we run inference in parallel
         // this might need to be investigated and fixed. For now we lock and process requests
         // one at a time.
-        // TODO: consider locking with a timeout: https://docs.rs/parking_lot/latest/parking_lot/type.Mutex.html#method.try_lock_for
+        let _lock = self.prompt_lock.try_lock_for(Duration::from_secs(120))
+            .ok_or(LLMError::Busy)?;
         let mut ctx = self.create_context(ctx_size)?;
         ctx.process(tokens_list)
     }

--- a/ltengine/src/main.rs
+++ b/ltengine/src/main.rs
@@ -254,8 +254,11 @@ async fn translate(req: HttpRequest, payload: web::Payload, args: web::Data<Arc<
     let prompt = pb.build(&q);
     
     let translated_text = if source != target {
-        llm.run_prompt(prompt.system, prompt.user).unwrap_or(q.clone())
-    }else{
+        llm.run_prompt(prompt.system, prompt.user).map_err(|e| {
+            let status = if e.is::<llm::LLMError>() { 503 } else { 500 };
+            ErrorResponse { error: e.to_string(), status }
+        })?
+    } else {
         q.clone()
     };
     


### PR DESCRIPTION
Concurrent requests serialize through a mutex. Previously the second request would block forever and silently return the original input on failure. Now it waits up to 120 seconds and returns HTTP 503 if the server is still busy.