### PR TITLE
Strip Gemma 4 thinking tokens from translation output

### DIFF
--- a/ltengine/src/llm.rs
+++ b/ltengine/src/llm.rs
@@ -208,6 +208,17 @@ impl LLMContext<'_>{
             self.ctx.decode(&mut batch).with_context(|| "Failed to eval")?;
         }
 
+        // Gemma 4 thinking mode emits thinking content before the actual response in two forms:
+        // 1. <|channel>thought\n...<channel|>answer  (full block with closing tag)
+        // 2. <|channel>thought answer                (no closing tag, space-separated)
+        let output = if let Some(pos) = output.find("<channel|>") {
+            output[pos + "<channel|>".len()..].to_owned()
+        } else if let Some(rest) = output.strip_prefix("<|channel>thought") {
+            rest.trim_start_matches(['\n', ' ']).to_owned()
+        } else {
+            output
+        };
+
         Ok(output)
     }
 }


### PR DESCRIPTION
Gemma 4 emits thinking content in two forms:
- <|channel>thought\n...<channel|>answer (full block with closing tag)
- <|channel>thought answer (no closing tag, space-separated)

Handle both cases so thinking tokens never leak into the translation result.